### PR TITLE
Ruby 1.9 "Not Modified" fix

### DIFF
--- a/lib/rack/coffee.rb
+++ b/lib/rack/coffee.rb
@@ -38,7 +38,7 @@ module Rack
         if env['HTTP_IF_MODIFIED_SINCE']
           cached_time = Time.parse(env['HTTP_IF_MODIFIED_SINCE'])
           if modified_time <= cached_time
-            return [304, {}, 'Not modified']
+            return [304, {}, ['Not modified']]
           end
         end
 


### PR DESCRIPTION
The "Not Modified" response body needs to be wrapped in an array for Ruby 1.9, or you get `Rack::Lint::LintError: Response body must respond to each` errors.
