### PR TITLE
Use 'coffee-script' gem instead of 'coffee' command

### DIFF
--- a/lib/rack/coffee.rb
+++ b/lib/rack/coffee.rb
@@ -22,7 +22,7 @@ module Rack
     end
     
     def brew(coffee)
-      CoffeeScript.compile File.read(coffee)
+      CoffeeScript.compile IO.read(coffee)
     end
 
     def not_modified

--- a/lib/rack/coffee.rb
+++ b/lib/rack/coffee.rb
@@ -1,6 +1,7 @@
 require 'time'
 require 'rack/file'
 require 'rack/utils'
+require 'coffee-script'
 
 module Rack
   class Coffee
@@ -18,13 +19,10 @@ module Rack
       @cache = opts[:cache]
       @ttl = opts[:ttl] || 86400
       @join = opts[:join]
-      @command = ['coffee', '-p']
-      @command.push('--bare') if opts[:nowrap] || opts[:bare]
-      @command = @command.join(' ')
     end
     
     def brew(coffee)
-      IO.popen("#{@command} #{coffee}")
+      CoffeeScript.compile File.read(coffee)
     end
 
     def not_modified

--- a/rack-coffee.gemspec
+++ b/rack-coffee.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rack>, [">= 0"])
+      s.add_runtime_dependency(%q<coffee-script>, [">= 0"])
     else
       s.add_dependency(%q<rack>, [">= 0"])
     end


### PR DESCRIPTION
Thanks for the great gem.  I don't have the 'coffee' command, so am using the coffee-script gem instead.  I believe this is how rails will do coffeescript in 3.1 (but haven't looked too closely).  This also resolves #6.
