### PR TITLE
Cache coffee files as compiled JS

### DIFF
--- a/lib/rack/coffee.rb
+++ b/lib/rack/coffee.rb
@@ -5,34 +5,52 @@ require 'rack/utils'
 module Rack
   class Coffee
     F = ::File
-    
-    attr_accessor :urls, :root
+
+    attr_accessor :class_urls, :urls, :root
     DEFAULTS = {:static => true}
     
     def initialize(app, opts={})
       opts = DEFAULTS.merge(opts)
       @app = app
       @urls = *opts[:urls] || '/javascripts'
+      @class_urls = opts[:class_urls] || '/javascripts/classes'
       @root = opts[:root] || Dir.pwd
       @server = opts[:static] ? Rack::File.new(root) : app
       @cache = opts[:cache]
       @ttl = opts[:ttl] || 86400
-      @command = ['coffee', '-p']
+      @output_path = opts[:output_path] || '/public'
+      
+      define_command opts
+    end
+    
+    def define_command(opts={})
+      @command = ['coffee', '-o', opts[:output_path]]
       @command.push('--bare') if opts[:nowrap] || opts[:bare]
       @command = @command.join(' ')
     end
     
     def brew(coffee)
-      IO.popen("#{@command} #{coffee}")
+      out = IO.popen("#{@command} #{coffee}")
+      out.readlines
+    end
+    
+    def read_file(path)
+      output = nil
+      F.open(path, "r") do |file|
+        output = file.read
+      end
+      output
     end
     
     def call(env)
       path = Utils.unescape(env["PATH_INFO"])
       return [403, {"Content-Type" => "text/plain"}, ["Forbidden\n"]] if path.include?('..')
       return @app.call(env) unless urls.any?{|url| path.index(url) == 0} and (path =~ /\.js$/)
+ 
       coffee = F.join(root, path.sub(/\.js$/,'.coffee'))
+      
       if F.file?(coffee)
-
+          
         modified_time = F.mtime(coffee)
 
         if env['HTTP_IF_MODIFIED_SINCE']
@@ -43,11 +61,22 @@ module Rack
         end
 
         headers = {"Content-Type" => "application/javascript", "Last-Modified" => F.mtime(coffee).httpdate}
+        
         if @cache
           headers['Cache-Control'] = "max-age=#{@ttl}"
           headers['Cache-Control'] << ', public' if @cache == :public
         end
-        [200, headers, brew(coffee)]
+        
+        bare = !coffee.match(Regexp.new("^#{@root}#{@class_urls}")).nil?
+        
+        output_path = bare ? F.join(".", @output_path, @class_urls) : F.join(".", @output_path, @urls)
+        define_command :bare => bare, :output_path => output_path
+        
+        brew(coffee)
+
+        out = read_file F.join(output_path, path.match(/[^\/]+$/)[0])
+        
+        [200, headers, out]
       else
         @server.call(env)
       end

--- a/lib/rack/coffee.rb
+++ b/lib/rack/coffee.rb
@@ -82,11 +82,12 @@ module Rack
         define_command :bare => bare, :output_path => output_path
         
         if @cache
-          F.delete F.join(output_path, path.match(/[^\/]+$/)[0])
+          js_file = F.join(output_path, path.match(/[^\/]+$/)[0])
+          F.delete js_file if F.file? js_file
           
           brew(coffee)
 
-          out = read_file F.join(output_path, path.match(/[^\/]+$/)[0])
+          out = read_file js_file
         
           [200, headers, out]
         else

--- a/lib/rack/coffee.rb
+++ b/lib/rack/coffee.rb
@@ -71,10 +71,10 @@ module Rack
 
         headers = {"Content-Type" => "application/javascript", "Last-Modified" => F.mtime(coffee).httpdate}
         
-        if @cache
-          headers['Cache-Control'] = "max-age=#{@ttl}"
-          headers['Cache-Control'] << ', public' if @cache == :public
-        end
+        # if @cache
+        #   headers['Cache-Control'] = "max-age=#{@ttl}"
+        #   headers['Cache-Control'] << ', public' if @cache == :public
+        # end
         
         bare = !coffee.match(Regexp.new("^#{@root}#{@class_urls}")).nil?
         

--- a/lib/rack/coffee.rb
+++ b/lib/rack/coffee.rb
@@ -89,9 +89,9 @@ module Rack
 
           out = read_file js_file
         
-          [200, headers, out]
+          [200, headers, [out]]
         else
-          [200, headers, brew(coffee)]
+          [200, headers, [brew(coffee)]]
         end
       else
         @server.call(env)

--- a/lib/rack/coffee.rb
+++ b/lib/rack/coffee.rb
@@ -82,6 +82,8 @@ module Rack
         define_command :bare => bare, :output_path => output_path
         
         if @cache
+          F.delete  F.join(output_path, path.match(/[^\/]+$/)[0])
+          
           brew(coffee)
 
           out = read_file F.join(output_path, path.match(/[^\/]+$/)[0])

--- a/lib/rack/coffee.rb
+++ b/lib/rack/coffee.rb
@@ -60,14 +60,14 @@ module Rack
       
       if F.file?(coffee)
           
-        modified_time = F.mtime(coffee)
-
-        if env['HTTP_IF_MODIFIED_SINCE']
-          cached_time = Time.parse(env['HTTP_IF_MODIFIED_SINCE'])
-          if modified_time <= cached_time
-            return [304, {}, 'Not modified']
-          end
-        end
+        # modified_time = F.mtime(coffee)
+        # 
+        # if env['HTTP_IF_MODIFIED_SINCE']
+        #   cached_time = Time.parse(env['HTTP_IF_MODIFIED_SINCE'])
+        #   if modified_time <= cached_time
+        #     return [304, {}, 'Not modified']
+        #   end
+        # end
 
         headers = {"Content-Type" => "application/javascript", "Last-Modified" => F.mtime(coffee).httpdate}
         

--- a/lib/rack/coffee.rb
+++ b/lib/rack/coffee.rb
@@ -83,6 +83,7 @@ module Rack
         
         if @cache
           js_file = F.join(output_path, path.match(/[^\/]+$/)[0])
+          puts "Caching @ #{js_file}"
           F.delete js_file if F.file? js_file
           
           brew(coffee)

--- a/lib/rack/coffee.rb
+++ b/lib/rack/coffee.rb
@@ -82,7 +82,7 @@ module Rack
         define_command :bare => bare, :output_path => output_path
         
         if @cache
-          F.delete  F.join(output_path, path.match(/[^\/]+$/)[0])
+          F.delete F.join(output_path, path.match(/[^\/]+$/)[0])
           
           brew(coffee)
 

--- a/lib/rack/coffee.rb
+++ b/lib/rack/coffee.rb
@@ -37,7 +37,9 @@ module Rack
     def brew(coffee)
       if @cache
         out = IO.popen("#{@command} #{coffee}")
-        out.readlines
+        s = out.readlines
+        out.close
+        s
       else
         IO.popen("#{@command} #{coffee}")
       end

--- a/lib/rack/coffee.rb
+++ b/lib/rack/coffee.rb
@@ -78,12 +78,11 @@ module Rack
         
         bare = !coffee.match(Regexp.new("^#{@root}#{@class_urls}")).nil?
         
-        output_path = bare ? F.join(".", @output_path, @class_urls) : F.join(".", @output_path, @urls)
+        output_path = bare ? F.join(@root, @output_path, @class_urls) : F.join(@root, @output_path, @urls)
         define_command :bare => bare, :output_path => output_path
         
         if @cache
           js_file = F.join(output_path, path.match(/[^\/]+$/)[0])
-          puts "Caching @ #{js_file}"
           F.delete js_file if F.file? js_file
           
           brew(coffee)


### PR DESCRIPTION
Hi Matt,

Not sure if you would be interested in this but, my fork of rack-coffee keeps a copy of the compiled JS file in a designated place so when you deploy up to production you can just have the JS server instead of requiring Coffee et al.

Cheers

Dan
