### PR TITLE
Return Content-Length header

### DIFF
--- a/lib/rack/coffee.rb
+++ b/lib/rack/coffee.rb
@@ -74,7 +74,7 @@ module Rack
       headers = {
         'Content-Type' => 'application/javascript',
         'Last-Modified' => mtime.httpdate,
-        'Content-Length' => contents.size.to_s
+        'Content-Length' => contents.bytesize.to_s
       }
       headers['Cache-Control'] = @cache_control if @cache_control
       headers

--- a/lib/rack/coffee.rb
+++ b/lib/rack/coffee.rb
@@ -70,10 +70,11 @@ module Rack
       cache_time && last_modified <= Time.parse(cache_time)
     end
 
-    def headers_for(mtime)
+    def headers_for(mtime, contents)
       headers = {
         'Content-Type' => 'application/javascript',
-        'Last-Modified' => mtime.httpdate
+        'Last-Modified' => mtime.httpdate,
+        'Content-Length' => contents.size.to_s
       }
       headers['Cache-Control'] = @cache_control if @cache_control
       headers
@@ -98,7 +99,7 @@ module Rack
       last_modified = source_files.map {|file| file.mtime }.max
       return not_modified if check_modified_since(env, last_modified)
       brewed = source_files.map{|file| brew(file) }.join("\n")
-      [200, headers_for(last_modified), [brewed]]
+      [200, headers_for(last_modified, brewed), [brewed]]
     end
   end
 end

--- a/test/javascripts/test.coffee
+++ b/test/javascripts/test.coffee
@@ -1,1 +1,1 @@
-alert("coffee")
+alert("coffee¿")

--- a/test/rack_coffee_test.rb
+++ b/test/rack_coffee_test.rb
@@ -35,6 +35,7 @@ class RackCoffeeTest < Test::Unit::TestCase
     assert_equal 200, result.status
     assert_match compiled_body_regex, result.body
     assert_equal File.mtime("#{@root}/javascripts/test.coffee").httpdate, result["Last-Modified"]
+    assert_equal result.body.size.to_s, result["Content-Length"]
   end
 
   def test_calls_app_on_coffee_miss

--- a/test/rack_coffee_test.rb
+++ b/test/rack_coffee_test.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require 'test/unit'
 begin
   require 'rack/mock'
@@ -22,7 +24,7 @@ class RackCoffeeTest < Test::Unit::TestCase
   def setup
     @root = File.expand_path(File.dirname(__FILE__))
     @options = {:root => @root}
-    @compiled_body_regex = /function.*alert\(\"coffee\"\)\;.*this/m
+    @compiled_body_regex = /function.*alert\(\"coffee¿\"\)\;.*this/m
   end
 
   def request(options={})
@@ -35,7 +37,7 @@ class RackCoffeeTest < Test::Unit::TestCase
     assert_equal 200, result.status
     assert_match compiled_body_regex, result.body
     assert_equal File.mtime("#{@root}/javascripts/test.coffee").httpdate, result["Last-Modified"]
-    assert_equal result.body.size.to_s, result["Content-Length"]
+    assert_equal result.body.bytesize.to_s, result["Content-Length"]
   end
 
   def test_calls_app_on_coffee_miss
@@ -101,7 +103,7 @@ class RackCoffeeTest < Test::Unit::TestCase
 
   def test_bare_option
     result = request({:bare => true}).get("/javascripts/test.js")
-    assert_equal "alert(\"coffee\");", result.body.strip
+    assert_equal "alert(\"coffee¿\");", result.body.strip
   end
 
   def test_join_option_with_join


### PR DESCRIPTION
I had trouble using rack-coffee through Nginx. Nginx gives a warning about missing Content-Length header (when compression is not used). This change adds the missing header.
